### PR TITLE
Fix check of merchant code for PHP 8

### DIFF
--- a/Helper/WidgetHelper.php
+++ b/Helper/WidgetHelper.php
@@ -61,7 +61,7 @@ class WidgetHelper extends \Magento\Framework\App\Helper\AbstractHelper
 
         }
 
-        if (strlen($merchant_code) == 0) {
+        if (empty($merchant_code)) {
 
             return array();
 


### PR DESCRIPTION
If the merchant code is empty, the value returned by the get of the config is null type. In PHP 8, strlen function no longer allows null type, it wants a string type, and it throws an exception that breaks the admin panel when creating widgets
![Schermata del 2022-12-15 17-30-40](https://user-images.githubusercontent.com/40766441/207915885-d8583c30-b21a-4663-bc9d-431d26ddf416.png)
