### PR TITLE
Fix "SQLSTATE[23000]: Integrity constraint violation: 1048 Column 'fe…

### DIFF
--- a/Model/ResourceModel/Review.php
+++ b/Model/ResourceModel/Review.php
@@ -25,13 +25,13 @@ class Review extends \Magento\Review\Model\ResourceModel\Review
             'title' => $object->getTitle(),
             'detail' => $object->getDetail(),
             'nickname' => $object->getNickname(),
-            'feedaty_source' => $object->getFeedatySource(),
-            'feedaty_source_id' => $object->getFeedatySourceId(),
-            'feedaty_product_review_id' => $object->getFeedatyProductReviewId(),
-            'feedaty_pagination' => $object->getFeedatyPagination(),
+            'feedaty_source' => $object->getFeedatySource() ?? '0',
+            'feedaty_source_id' => $object->getFeedatySourceId() ?? '0',
+            'feedaty_product_review_id' => $object->getFeedatyProductReviewId() ?? '0',
+            'feedaty_pagination' => $object->getFeedatyPagination() ?? '0',
             'feedaty_create' => $object->getFeedatyCreate(),
             'feedaty_update' => $object->getFeedatyUpdate(),
-            'feedaty_product_mediated' => $object->getFeedatyProductMediated(),
+            'feedaty_product_mediated' => $object->getFeedatyProductMediated() ?? '0',
         ];
         $select = $connection->select()->from($this->_reviewDetailTable, 'detail_id')->where('review_id = :review_id');
         $detailId = $connection->fetchOne($select, [':review_id' => $object->getId()]);


### PR DESCRIPTION
…edaty_source' cannot be null" error on Magento 2.4.5

Detailed error after manual review from product page:

SQLSTATE[23000]: Integrity constraint violation: 1048 Column 'feedaty_source' cannot be null, query was: INSERT INTO `review_detail` (`title`, `detail`, `nickname`, `feedaty_source`, `feedaty_source_id`, `feedaty_product_review_id`, `feedaty_pagination`, `feedaty_create`, `feedaty_update`, `feedaty_product_mediated`, `store_id`, `customer_id`, `review_id`) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)