### PR TITLE
2.10.9

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -35,7 +35,7 @@
         "AFL-3.0"
     ],
 
-    "version": "2.10.8-stable",
+    "version": "2.10.9-stable",
 
 	"type": "magento2-module",
 

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-    <module name="Feedaty_Badge" setup_version="2.10.8">
+    <module name="Feedaty_Badge" setup_version="2.10.9">
         <sequence>
             <module name="Magento_Widget" />
         </sequence>

--- a/view/frontend/templates/product-snippet.phtml
+++ b/view/frontend/templates/product-snippet.phtml
@@ -1,5 +1,4 @@
 <?php
-
 /* @var $block \Feedaty\Badge\Block\ProductSnippet */
 $store_scope = \Magento\Store\Model\ScopeInterface::SCOPE_STORE;
 
@@ -77,7 +76,8 @@ if ($product !== null) {
     /**
      * Product Desc
      */
-    $productDescription = strip_tags($block->getProductDescription());
+
+    $productDescription = $block->getProductDescription() !== null ? strip_tags($block->getProductDescription()) : '';
 
     /**
      * Merchant Code


### PR DESCRIPTION
Fix Exception #0 (Exception): Deprecated Functionality: strip_tags(): Passing null to parameter #1 ($string) of type string is deprecated 